### PR TITLE
修复图片读取异常以及SIFT特征提取不到导致的异常

### DIFF
--- a/vision/bof.py
+++ b/vision/bof.py
@@ -57,6 +57,7 @@ class BoF(object):
         app.cli.add_command(extract)
         app.cli.add_command(evaluate)
 
+    # todo
     def train(self):
         print("Get sift features of %d images" % self.n)
 
@@ -147,7 +148,6 @@ class BoF(object):
 
         # wgc = WGC(self.n, 17, 7)
         scores = np.zeros(self.n)
-        print("n is: %d" % self.n)
         # 匹配所有所属聚类相同且对应编码的hamming距离不超过阈值的特征
         for (ang_q, sca_q), sig_q, lbl_q in zip(geo, signature, label):
             for img_id, ang_t, sca_t, sig_t in self.entries[lbl_q]:

--- a/vision/bof.py
+++ b/vision/bof.py
@@ -28,6 +28,12 @@ class BoF(object):
         self.inv = InvFile(self.k, self.n)
 
     def init_app(self, app):
+
+        @click.command('train')
+        # todo
+        def train():
+            self.train()
+
         @click.command('extract')
         def extract():
             self.extract()
@@ -47,18 +53,38 @@ class BoF(object):
             print("mAP of the %d images is %4f, %4fs per query" %
                   (len(queries), mAP, mT))
 
+        app.cli.add_command(train)
         app.cli.add_command(extract)
         app.cli.add_command(evaluate)
+
+    def train(self):
+        print("Get sift features of %d images" % self.n)
 
     def extract(self):
         print("Get sift features of %d images" % self.n)
         # 获取每幅图的所有关键点和对应的描述子
-        keypoints, descriptors = zip(
-            *[self.sift.extract(cv2.imread(self.ukbench[i],
-                                           cv2.IMREAD_GRAYSCALE),
-                                rootsift=True)
-                for i in range(self.n)]
-        )
+        keypoints = []
+        descriptors = []
+        numNoDes = 0
+        badImgs = []
+        for i in range(self.n):
+            print("%d (%d), %s" %((i+1), self.n, self.ukbench[i]))
+            img = cv2.imread(self.ukbench[i], cv2.IMREAD_GRAYSCALE)
+            if img is None:
+                badImgs.append(self.ukbench[i])
+                numNoDes += 1
+                continue
+            status, kpt, des = self.sift.extract(img, rootsift=True)
+            if status == 0:
+                badImgs.append(self.ukbench[i])
+                numNoDes += 1
+                continue
+            keypoints.append(kpt)
+            descriptors.append(des)
+        for badImg in badImgs:
+            self.ukbench.remove(badImg)
+        self.n = self.n - numNoDes
+        self.inv.n = self.n
         for i, (kp, des) in enumerate(zip(keypoints, descriptors)):
             self.sift.dump(kp, des, str(i))
         # keypoints, descriptors = zip(
@@ -108,8 +134,7 @@ class BoF(object):
     def match(self, uri, top_k=20, ht=23, rerank=True):
         kmeans, he, norms, idf = self.bof
         # 计算关键点和描述子
-        kp, des = self.sift.extract(cv2.imread(uri, cv2.IMREAD_GRAYSCALE),
-                                    rootsift=True)
+        status, kp, des = self.sift.extract(cv2.imread(uri, cv2.IMREAD_GRAYSCALE), rootsift=True)
         # 计算每个关键点对应的关于角度和尺度的几何信息
         geo = [(np.radians(k.angle), np.log2(k.size)) for k in kp]
         # 映射所有描述子到距其最近的聚类并得到该聚类的索引
@@ -122,6 +147,7 @@ class BoF(object):
 
         # wgc = WGC(self.n, 17, 7)
         scores = np.zeros(self.n)
+        print("n is: %d" % self.n)
         # 匹配所有所属聚类相同且对应编码的hamming距离不超过阈值的特征
         for (ang_q, sca_q), sig_q, lbl_q in zip(geo, signature, label):
             for img_id, ang_t, sca_t, sig_t in self.entries[lbl_q]:
@@ -157,6 +183,7 @@ class BoF(object):
     def bof(self):
         with open(self.bof_path, 'rb') as bof_pkl:
             kmeans, he, norms, idf = pickle.load(bof_pkl)
+        self.n = norms.shape[0]
         return kmeans, he, norms, idf
 
     @cached_property

--- a/vision/sift.py
+++ b/vision/sift.py
@@ -15,10 +15,14 @@ class SIFT(object):
 
     def extract(self, gray, rootsift=True):
         # 计算图片的所有关键点和对应的描述子
+        status = 0
         kp, des = self.extractor.detectAndCompute(gray, None)
+        if len(kp) <= 0:
+            return status, kp, des
         if rootsift:
             des = self.rootsift(des)
-        return kp, des
+        status = 1
+        return status, kp, des
 
     def match(self, des_q, des_t):
         ratio = 0.7  # 按照Lowe的测试


### PR DESCRIPTION
主要修复了两个部分，分别为：

1. 图片为空时，导致无法提取SIFT而抛出异常
2. SIFT图片读取正常，但是关键点提取不到，导致程序的异常

代码经过测试OK